### PR TITLE
[Backend] POST /auth/login

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
     "linebreak-style": ["error", "unix"],
     "quotes": ["error", "double"],
     "semi": ["error", "always"],
-    "no-console": "warn",
+    "no-console": "off",
     "no-var": "off",
     "no-unused-vars": ["error", { "args": "none" }]
   }

--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const logger = require("morgan");
 const connectMongoDB = require("./loaders/db");
 
 const indexRouter = require("./routes/index");
+const authRouter = require("./routes/auth");
 
 const app = express();
 
@@ -26,6 +27,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 
 app.use("/", indexRouter);
+app.use("/auth", authRouter);
 
 app.use((req, res, next) => {
   next(createError(404));

--- a/bin/www
+++ b/bin/www
@@ -82,5 +82,6 @@ function onError(error) {
 function onListening() {
   const addr = server.address();
   const bind = typeof addr === "string" ? "pipe " + addr : "port " + addr.port;
+  console.log("Listening to Port " + port);
   debug("Listening on " + bind);
 }

--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -1,0 +1,39 @@
+const jwt = require("jsonwebtoken");
+const createError = require("http-errors");
+
+const { User } = require("../models/User");
+
+exports.handleLogin = async (req, res, next) => {
+  try {
+    const { email, name } = req.body;
+    const foundUser = await User.findOne({ email }).lean();
+    let user = foundUser;
+
+    if (!foundUser) {
+      user = await User.create({
+        email,
+        name,
+      });
+    }
+
+    const accessToken = jwt.sign(
+      { email: user.email },
+      process.env.ACCESS_TOKEN_SECRET,
+      { expiresIn: "1d" }
+    );
+
+    res.status(200).json({
+      result: "success",
+      data: {
+        user: {
+          _id: user._id,
+          email: user.email,
+          name: user.name,
+        },
+        accessToken,
+      },
+    });
+  } catch (err) {
+    next(createError(err));
+  }
+};

--- a/loaders/db.js
+++ b/loaders/db.js
@@ -2,7 +2,7 @@ const mongoose = require("mongoose");
 
 async function connectMongoDB() {
   try {
-    await mongoose.connect(process.env.MONGODB_URL, () => {
+    await mongoose.connect(process.env.MONGO_DB_URL, () => {
       console.log("Successfully connect to mongoDB");
     });
   } catch (err) {

--- a/middlewares/validateMiddleware.js
+++ b/middlewares/validateMiddleware.js
@@ -1,0 +1,18 @@
+const createError = require("http-errors");
+
+module.exports = (validator) => {
+  return (req, res, next) => {
+    const { error } = validator(req.body);
+
+    if (error) {
+      return next(
+        createError.BadRequest({
+          result: "failed",
+          message: error.details[0].message,
+        })
+      );
+    }
+
+    next();
+  };
+};

--- a/middlewares/verifyToken.js
+++ b/middlewares/verifyToken.js
@@ -1,0 +1,30 @@
+const jwt = require("jsonwebtoken");
+const createError = require("http-errors");
+
+exports.verifyToken = (req, res, next) => {
+  const accessToken = req.headers.accessToken;
+
+  if (!accessToken) {
+    next(createError.Unauthorized("You need to login first."));
+    return;
+  }
+
+  jwt.verify(accessToken, process.env.ACCESS.TOKEN_SECRET, (err, user) => {
+    if (err) {
+      switch (err.name) {
+        case "JsonWebTokenError":
+          next(createError.BadRequest("Your token is not verified."));
+          return;
+        case "TokenExpiredError":
+          next(createError.BadRequest("Your token has expired."));
+          return;
+        default:
+          next(createError.Unauthorized("Invalid Token"));
+      }
+    }
+
+    req.user = user;
+
+    next();
+  });
+};

--- a/models/User.js
+++ b/models/User.js
@@ -1,0 +1,31 @@
+const mongoose = require("mongoose");
+const Joi = require("joi");
+
+const userSchema = new mongoose.Schema({
+  email: {
+    type: String,
+    required: [true, "Email is reuiqred"],
+    unique: true,
+    lowercase: true,
+  },
+  name: {
+    type: String,
+    required: [true, "Name is required"],
+  },
+});
+
+const User = mongoose.model("User", userSchema);
+
+const validateUser = (user) => {
+  const schema = Joi.object({
+    email: Joi.string().required(),
+    name: Joi.string().required(),
+  });
+
+  return schema.validate(user);
+};
+
+module.exports = {
+  User,
+  validateUser,
+};

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,10 @@
+const express = require("express");
+const router = express.Router();
+
+const validateMiddleware = require("../middlewares/validateMiddleware");
+const { validateUser } = require("../models/User");
+const { handleLogin } = require("../controllers/auth.controller");
+
+router.post("/login", [validateMiddleware(validateUser)], handleLogin);
+
+module.exports = router;


### PR DESCRIPTION
## 칸반 링크
- [[Backend] POST /auth/login](https://sangminiam.notion.site/Backend-POST-auth-login-74beb93069a347fbbb0479632518b4ce)
  
## 카드에서 구현 혹은 해결하려는 내용
- `/auth/login` 라우터 및 컨트롤러
- JWT 관련 로직 - 로그인 성공시 JWT 토큰 발급
- 미들웨어 - Validator with Joi, verifyToken


## 테스트 방법
- postman으로 `/auth/login` POST 요청

## 기타 사항
* Null