### PR TITLE
[Backend] GET /diaries

### DIFF
--- a/controllers/diary.controller.js.js
+++ b/controllers/diary.controller.js.js
@@ -1,7 +1,9 @@
+const createError = require("http-errors");
+const differenceInMonths = require("date-fns/differenceInMonths");
+const Sentiment = require("sentiment");
+
 const Diary = require("../models/Diary");
 const { User } = require("../models/User");
-const Sentiment = require("sentiment");
-const createError = require("http-errors");
 
 const sentiment = new Sentiment();
 
@@ -28,6 +30,73 @@ exports.createDiary = async (req, res, next) => {
     res.json({
       result: "success",
       data: null,
+    });
+  } catch (err) {
+    next(createError(err));
+  }
+};
+
+exports.getPaginatedDiaries = async (req, res, next) => {
+  try {
+    let query = Diary.find();
+
+    const page = parseInt(req.query.page) || 1;
+    const pageSize = parseInt(req.query.limit) || 9;
+    const skip = (page - 1) * pageSize;
+    const total = await Diary.countDocuments();
+
+    const pages = Math.ceil(total / pageSize);
+
+    query = query.skip(skip).limit(pageSize);
+
+    if (page > pages) {
+      next();
+      return;
+    }
+
+    const result = await query;
+
+    res.status(200).json({
+      result: "success",
+      data: {
+        page,
+        pages,
+        diaries: result,
+        count: result.length,
+      },
+    });
+  } catch (err) {
+    next(createError(err));
+  }
+};
+
+exports.getDiaries = async (req, res, next) => {
+  try {
+    const { startDate, endDate } = req.query;
+
+    const monthGap = differenceInMonths(new Date(endDate), new Date(startDate));
+
+    if (startDate > endDate || monthGap > 12) {
+      next(createError.BadRequest());
+      return;
+    }
+
+    const { email } = req.user;
+    const { _id: userId } = await User.findOne({ email }).select("_id").lean();
+
+    const diaries = await Diary.find({
+      createdBy: userId,
+      $and: [
+        { createdAt: { $gte: startDate } },
+        { createdAt: { $lte: endDate } },
+      ],
+    });
+
+    res.json({
+      result: "success",
+      data: {
+        diaries,
+      },
     });
   } catch (err) {
     next(createError(err));

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "aws-sdk": "^2.1084.0",
         "cookie-parser": "~1.4.4",
         "cors": "^2.8.5",
+        "date-fns": "^2.28.0",
         "debug": "~2.6.9",
         "dotenv": "^16.0.0",
         "express": "~4.16.1",
@@ -1106,6 +1107,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -5644,6 +5657,11 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true
+    },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "aws-sdk": "^2.1084.0",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
+    "date-fns": "^2.28.0",
     "debug": "~2.6.9",
     "dotenv": "^16.0.0",
     "express": "~4.16.1",

--- a/routes/diary.js
+++ b/routes/diary.js
@@ -1,10 +1,16 @@
 const express = require("express");
 const router = express.Router();
 
-const { createDiary } = require("../controllers/diary.controller.js");
+const {
+  createDiary,
+  getPaginatedDiaries,
+  getDiaries,
+} = require("../controllers/diary.controller.js");
 const { uploadS3 } = require("../middlewares/multer.js");
 const { verifyToken } = require("../middlewares/verifyToken");
 
+router.get("/", verifyToken, getDiaries);
+router.get("/pagination", verifyToken, getPaginatedDiaries);
 router.post("/", verifyToken, uploadS3.single("audio"), createDiary);
 
 module.exports = router;


### PR DESCRIPTION
## 칸반 링크
* [[Backend] GET /diaries](https://sangminiam.notion.site/Backend-GET-diaries-0c3c9de45b10424ba90a026a136f110f)
  
## 카드에서 구현 혹은 해결하려는 내용
- `/diaries` 
유저와 일치하고 startDate와 endDate사이의 다이어리들을 불러온다. startDate와 endDate는 12개월이 넘어갈 수 없으며 startDate가 endDate보다 크면 안된다.
- `/diaries/pagination`
유저와 일치하는 정보의 다이어리들을 불러온다. 페이지네이션으로 한 페이지당 9개를 클라이언트에게 전송한다.

## 테스트 방법
- postman을 사용하여 GET 요청 테스트할 수 있습니다.
- `/diaries?startDate=2022-02-01&endDate=2022-03-05`
- `/diaries/pagination?page=1`

## 기타 사항
* Null