### PR TITLE
[Backend] GET /diaries (Merge pagination)

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const cors = require("cors");
 const logger = require("morgan");
 
 const connectMongoDB = require("./loaders/db");
+const { RESPONSE } = require("./constants");
 
 const indexRouter = require("./routes/index");
 const authRouter = require("./routes/auth");
@@ -40,7 +41,7 @@ app.use((err, req, res, next) => {
 
   if (req.app.get("env") === "development") {
     res.json({
-      result: err.result || "error",
+      result: err.result || RESPONSE.ERROR,
       message: err.message,
       stack: err.stack,
     });
@@ -53,7 +54,7 @@ app.use((err, req, res, next) => {
   }
 
   res.json({
-    result: err.result || "error",
+    result: err.result || RESPONSE.ERROR,
     message: err.message,
   });
 });

--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -2,6 +2,7 @@ const jwt = require("jsonwebtoken");
 const createError = require("http-errors");
 
 const { User } = require("../models/User");
+const { RESPONSE } = require("../constants");
 
 exports.handleLogin = async (req, res, next) => {
   try {
@@ -23,7 +24,7 @@ exports.handleLogin = async (req, res, next) => {
     );
 
     res.status(200).json({
-      result: "success",
+      result: RESPONSE.SUCCESS,
       data: {
         user: {
           _id: user._id,

--- a/middlewares/validateMiddleware.js
+++ b/middlewares/validateMiddleware.js
@@ -1,4 +1,5 @@
 const createError = require("http-errors");
+const { RESPONSE } = require("../constants");
 
 module.exports = (validator) => {
   return (req, res, next) => {
@@ -7,7 +8,7 @@ module.exports = (validator) => {
     if (error) {
       return next(
         createError.BadRequest({
-          result: "failed",
+          result: RESPONSE.FAIL,
           message: error.details[0].message,
         })
       );

--- a/routes/diary.js
+++ b/routes/diary.js
@@ -3,14 +3,12 @@ const router = express.Router();
 
 const {
   createDiary,
-  getPaginatedDiaries,
   getDiaries,
 } = require("../controllers/diary.controller.js");
 const { uploadS3 } = require("../middlewares/multer.js");
 const { verifyToken } = require("../middlewares/verifyToken");
 
 router.get("/", verifyToken, getDiaries);
-router.get("/pagination", verifyToken, getPaginatedDiaries);
 router.post("/", verifyToken, uploadS3.single("audio"), createDiary);
 
 module.exports = router;


### PR DESCRIPTION
## 칸반 링크
* [[Backend] GET /diaries (Merge pagination)](https://sangminiam.notion.site/Backend-GET-diaries-Merge-pagination-f3364b184261449585c57f7a724fb31c)
  
## 카드에서 구현 혹은 해결하려는 내용
- 기존 GET `/diaries` 라우터와 `/diaries/pagination` 을 병합

## 테스트 방법
- `/diaries?startDate=2022-02-01&endDate=2022-03-01`
- `/diaries?startDate=2022-02-01&endDate=2022-03-01&page=1`
- 위와 같이 쿼리에 page를 넣을 경우에 pagination이 적용된 데이터가 전송된다.

## 기타 사항
* Null