### PR TITLE
[Backend] GET /diaries sentiment 필터 추가

### DIFF
--- a/constants/index.js
+++ b/constants/index.js
@@ -4,6 +4,11 @@ exports.RESPONSE = {
   ERROR: "error",
 };
 
+exports.DIARY_SENTIMENT = {
+  POSITIVE: "positive",
+  NEGATIVE: "negative",
+};
+
 exports.DATE_FORMAT = {
   YYYY_MM_DD: "yyyy-MM-dd",
 };


### PR DESCRIPTION
## 칸반 링크
* [[Backend] GET /diaries sentiment 필터 추가](https://sangminiam.notion.site/Backend-GET-diaries-sentiment-55ef707753e44eefadc9981404dc9010)
  
## 카드에서 구현 혹은 해결하려는 내용
- sentiment 필터링 옵션 추가

## 테스트 방법
- Postman
  - `/diaries&startDate=2022-02-01&endDate=2022-03-31&sentiment=positive`
  - `/diaries&startDate=2022-02-01&endDate=2022-03-31&sentiment=negative`

## 기타 사항
* Null